### PR TITLE
[udisk2] Can't detach before unmounting/locking

### DIFF
--- a/udiskie/mount.py
+++ b/udiskie/mount.py
@@ -236,8 +236,8 @@ class Mounter(object):
     def detach_device(self, device, force=False):
         """Detach a device after unmounting all its mounted filesystems."""
         log = logging.getLogger('udiskie.mount.detach_device')
-        drive = device.drive
-        if not (drive.is_drive and drive.is_detachable):
+        drive = device.root
+        if not drive.is_detachable:
             log.debug('drive not detachable: %s' % drive)
             return False
         if force:

--- a/udiskie/udisks1.py
+++ b/udiskie/udisks1.py
@@ -138,6 +138,8 @@ class OnlineDevice(DBusProxy, DeviceBase):
         else:
             return self
 
+    root = drive
+
     @property
     def is_detachable(self):
         """Check if the drive that owns this device can be detached."""

--- a/udiskie/udisks2.py
+++ b/udiskie/udisks2.py
@@ -428,6 +428,17 @@ class Device(object):
             return self.udisks[self.I.Block.property.Drive]
         return None
 
+    @property
+    def root(self):
+        """
+        Get the top level block device in the ancestry of this device.
+        """
+        drive = self.drive
+        for device in self.udisks:
+            if not device.is_drive and device.is_toplevel and device.drive == drive:
+                return device
+        return None
+
     #----------------------------------------
     # Partition
     #----------------------------------------


### PR DESCRIPTION
The udisks2 backend fails to detach a drive if not first unmounted (that is, it doesn't automatically unmount it (or unlock it if locked) first). The udisks1 backend works as expected.
