### PR TITLE
[udisks2] Mounts drive twice after unlocking

### DIFF
--- a/udiskie/automount.py
+++ b/udiskie/automount.py
@@ -16,8 +16,3 @@ class AutoMounter(object):
     def media_added(self, udevice):
         self.mounter.add_device(udevice)
 
-    # Automount LUKS cleartext holders after they have been unlocked.
-    # Why doesn't this work in device_added?
-    def device_unlocked(self, udevice):
-        self.mounter.add_device(udevice.luks_cleartext_holder)
-


### PR DESCRIPTION
After unlocking an encrypted drive, I get the following messages:

```
unlocked device /org/freedesktop/UDisks2/block_devices/sdc on /dev/dm-1
mounted device /org/freedesktop/UDisks2/block_devices/dm_2d1 on /run/media/<user>/<drive>
failed to mount device /org/freedesktop/UDisks2/block_devices/dm_2d1: org.freedesktop.UDisks2.Error.AlreadyMounted: Device /dev/dm-1 is already mounted at `/run/media/<user>/<drive>'.
```

The drive mounts correctly.
