### PR TITLE
Tray left click menu

### DIFF
--- a/udiskie/cli.py
+++ b/udiskie/cli.py
@@ -251,9 +251,9 @@ class Umount(_EntryPoint):
         parser.add_option('-a', '--all', dest='all', default=False,
                           action='store_true', help='all devices')
         parser.add_option('-e', '--eject', dest='eject', default=False,
-                          action='store_true', help='Eject drive')
+                          action='store_true', help='Eject media from drive (CDROM etc)')
         parser.add_option('-d', '--detach', dest='detach', default=False,
-                          action='store_true', help='Detach drive')
+                          action='store_true', help='Detach drive (power off)')
         return parser
 
     @classmethod

--- a/udiskie/tray.py
+++ b/udiskie/tray.py
@@ -44,7 +44,7 @@ class UdiskieMenu(object):
         'unlock': 'Unlock %s',
         'lock': 'Lock %s',
         'eject': 'Eject %s',
-        'detach': 'Detach %s',
+        'detach': 'Unpower %s',
         'quit': 'Quit', }
 
     def __init__(self, mounter, actions):


### PR DESCRIPTION
Hi there,

its me again :). I have another suggestion: enable the left click on the tray icon. For some people (me included) it might be confusing using right click on the icon for the direct action. Having both saves time when you realize you clicked the wrong button :).

The code would be something like this (taken from gnome-encfs-manager):

```
self._conn = self._icon.connect("activate", self._left_click_event)

def _left_click_event(self, icon):
    """Handle a right click event (show the menu)."""
    m = self.create_context_menu()
    m.show_all()
    m.popup(parent_menu_shell=None,
            parent_menu_item=None,
            func=gtk.status_icon_position_menu,
            button=0,
            activate_time=gtk.get_current_event_time(),
            data=icon)
```

That works (already tested). I tried to re-use _right_click_event setting default values for button=0 and time=gtk.get_current_event_time(), but surprisingly it made the menu appear and dissapear inmediately.

Nevertheless, I'd go a little further. I'd also like to have a different menu (triggered by this left click). In this menu the currently mounted devices are listed and, on click, they are detached. Think on it on a shortcut to detach/umount/eject action, which for me it will be the 95% of the times I go to the tray icon.

Regards
