### PR TITLE
Eject action using udisks2 fails with pendrive. No information is give except on console log output 

### DIFF
--- a/udiskie/udisks2.py
+++ b/udiskie/udisks2.py
@@ -276,7 +276,10 @@ class Device(object):
     @property
     def is_partition(self):
         """Check if the device has a partition slave."""
-        return bool(self._I.Partition)
+        # Sometimes udisks2 empties the Partition interface before removing
+        # the device. In this case, we want to report .is_partition=False, so
+        # properties like .partition_slave will not be used.
+        return bool(self._I.Partition and self.partition_slave)
 
     @property
     def is_filesystem(self):


### PR DESCRIPTION
I have  8GB pen drive (sdb), with a single NTFS partition (sdb1). When using udisks2, actions for that drive include umount, eject, and detach. If I click eject, I have this on the console:
failed to eject device /org/freedesktop/UDisks2/block_devices/sdb

I think this kind of fails should be shown on a libnotify notification. 

I can umount or detach without problems. 
