### PR TITLE
python configuration file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@ CHANGELOG
 
 There are some backward incompatible changes, hence the version break:
 
-- default configuration path is now '$XDG_CONFIG_HOME/udiskie.conf'
-- command line parameter '-f'/'--filters' renamed to '-C'/'--config'
-- add sections in config file to disable individual mount notifications and
+- the config file is now a python script at '$XDG_CONFIG_HOME/udiskie.py'
+- command line parameter '-f'/'--filters' replaced by '-C'/'--config'
+- add config variables to disable individual mount notifications and
   set defaults for some program options (udisks version, prompt, etc)
 - refactor ``udiskie.cli``, ``udiskie.config`` and ``udiskie.tray``
 - revert 'make udiskie a namespace package'

--- a/doc/udiskie.8.txt
+++ b/doc/udiskie.8.txt
@@ -105,43 +105,8 @@ Mount '/dev/sdb1':
 
 Configuration
 -------------
-*udiskie* uses filters to apply additional mount options. On startup *udiskie* reads the filters in `$XDG_CONFIG_HOME/udiskie.conf` (or the file specified with *-C*). Filters can match the filesystem type or the device UUID. The option '__ignore__' instructs udiskie not to automount and display the matched device. The configuration file can also be used to specify defaults for some of the command line parameters.
+The config file at '$XDG_CONFIG_HOME/udiskie.py' (e.g. '~/.config/udiskie.py') is executed once on startup, after processing the command line. For an example config, see the file 'udiskie/config_example.py'.
 
-Example Configuration File
---------------------------
-----------------------------------------------------------------------
-[mount_options]
-fstype.vfat=sync
-uuid.9d53-13ba=noexec,nodev
-uuid.abcd-ef01=__ignore__
-
-[program_options]
-# Allowed values are '1' and '2'
-udisks_version=2
-# 'zenity', 'systemd-ask-password' or user program:
-password_prompt=zenity
-# valid values are: 'AutoTray', 'TrayIcon'
-tray=AutoTray
-# Leave empty to set to ``False``:
-automount=
-# Use '1' for ``True``:
-suppress_notify=1
-# Default program:
-file_manager=xdg-open
-
-[notifications]
-# Default timeout in seconds:
-timeout=1.5
-# Overwrite timeout for 'device_mounted' notification:
-device_mounted=5
-# Leave empty to disable:
-device_unmounted=
-device_added=
-device_removed=
-# Use the libnotify default timeout:
-device_unlocked=-1
-device_locked=-1
-----------------------------------------------------------------------
 
 See Also
 --------

--- a/udiskie/cli.py
+++ b/udiskie/cli.py
@@ -71,9 +71,6 @@ class _EntryPoint(object):
         parser.add_option('-2', '--use-udisks2', dest='udisks_version',
                           action='store_const', default=0, const=2,
                           help='use udisks2 as underlying daemon (experimental)')
-        parser.add_option('-f', '--filters', dest='config_file',
-                          action='store', default=None,
-                          metavar='FILE', help='synonym of --config [deprecated]')
         parser.add_option('-C', '--config', dest='config_file',
                           action='store', default=None,
                           metavar='FILE', help='config file')
@@ -143,7 +140,7 @@ class Daemon(_EntryPoint):
         daemon = udisks_service_object('Daemon', int(options.udisks_version))
         browser = udiskie.prompt.browser(options.file_manager)
         mounter = udiskie.mount.Mounter(
-            filter=config.filter_options,
+            filter=config.mount_option_filter,
             prompt=udiskie.prompt.password(options.password_prompt),
             browser=browser,
             udisks=daemon)
@@ -158,7 +155,7 @@ class Daemon(_EntryPoint):
             notify_service.init('udiskie.mount')
             notify = udiskie.notify.Notify(notify_service,
                                            browser=browser,
-                                           config=config.notifications)
+                                           config=config.notification_timeouts)
             notify.subscribe(daemon)
 
         # tray icon (optional):
@@ -217,7 +214,7 @@ class Mount(_EntryPoint):
         import udiskie.mount
         import udiskie.prompt
         mounter = udiskie.mount.Mounter(
-            filter=config.filter_options,
+            filter=config.mount_option_filter,
             prompt=udiskie.prompt.password(options.password_prompt),
             udisks=udisks_service_object('Sniffer', int(options.udisks_version)))
         return cls(mounter=mounter)

--- a/udiskie/config_example.py
+++ b/udiskie/config_example.py
@@ -1,0 +1,41 @@
+"""
+This is an example configuration file.
+"""
+from collections import defaultdict
+
+from udiskie.config import *
+
+
+config = Config(
+    # set fallbacks for program options:
+    udisks_version=1,                           # set UDisks version
+    password_prompt='zenity',                   # set the password program
+    tray='TrayIcon',                            # default tray class
+    automount=False,                            # disable automounting
+    suppress_notify=True,                       # show notifications
+    file_manager='xdg-open',                    # set file manager
+
+    # add mount options for specific devices, note that just the first
+    # matching filter will be used
+    mount_option_filter = FilterMatcher(
+        OptionFilter('id_uuid', 'abcd-ef00', ['ro', 'noexec']),
+        OptionFilter('id_uuid', 'abcd-ef01', ['__ignore__']),
+        # lesser filters (id_type) shoud be sorted below more specific
+        # filters (id_uuid), order matters:
+        OptionFilter('id_type', 'vfat', ['nosync']),
+    ),
+
+    # set timeouts for notifications:
+    notification_timeouts = defaultdict(
+        # number > 0    timeout in seconds 
+        # -1            use libnotify default
+        # False, None   disable notification
+        lambda: 5,                              # fallback value
+        device_mounted=3,                       # filesystem is mounted
+        device_unmounted=3,                     # filesystem is unmounted
+        device_added=False,                     # drive appeared
+        device_removed=False,                   # drive disappeared
+        device_unlocked=-1,                     # LUKS partition is unlocked
+        device_locked=1.5,                      # LUKS partition is locked
+    )
+)

--- a/udiskie/notify.py
+++ b/udiskie/notify.py
@@ -107,18 +107,9 @@ class Notify(object):
         return notification
 
     def _enabled(self, event):
-        return self._get_timeout(event) is not None
+        return self._get_timeout(event) not in (None, False)
 
     def _get_timeout(self, event):
         if not self._config:
             return -1
-        try:
-            timeout = self._config[event]
-        except KeyError:
-            timeout = self._config.get('timeout', -1)
-        if timeout in ('', None):
-            return None
-        try:
-            return int(timeout)
-        except ValueError:
-            return float(timeout)
+        return self._config.get(event, -1)


### PR DESCRIPTION
Replace the current .conf file with a python configuration file (like in buildbot/sphinx/scons). This will make the config file more powerful for user extensions. Apart from that, some weird config syntax will become more natural:
- just set options to `False` or `True`, instead of empty string/'0'/'False' strings or similar
- separate arguments for key and value of matching property of filter and list for mount options (instead of weird expression matched by regex)
