### PR TITLE
Allow user level instalation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ CHANGELOG
 - allow to overwrite udiskies default handleability settings
 - raise exception if --config file doesn't exist
 - add --options parameter for udiskie-mount
+- simplify local installations
 
 
 0.7.0

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,13 @@ it like so:
     cp ./icons/scalable /usr/share/icons/hicolor -r
     gtk-update-icon-cache /usr/share/icons/hicolor
 
+When doing a local installation, for example in a virtualenv, you can
+manually change the installation prefix for the icon data files like so:
+
+.. code-block:: bash
+
+    python setup.py install --install-data ~/.local
+
 The icons roughly follow the `Tango style guidelines`_. Some icons incorporate
 the CDROM icon of the base icon theme of the `Tango desktop project`_
 (released into the public domain).

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ except IOError:
     pass
 
 
-theme_base = path.join(sys.prefix, 'share/icons/hicolor')
+theme_base = path.join('share/icons/hicolor')
 icon_resolutions = ([('scalable', 'svg')] +
                     [('{0}x{0}'.format(res), 'png') for res in [16]])
 icon_classes = {'actions': ('mount', 'unmount',


### PR DESCRIPTION
```
error: Setup script exited with error: SandboxViolation: open('/usr/share/icons/hicolor/scalable/actions/udiskie-mount.svg', 'wb') {}
```

As udiskie works at the user level it would be nice to be able to install it entirely under home. You could use `~/.local/share/icons`.
