### PR TITLE
Specify required versions for gi in setup.py (required by newest gi version)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ from glob import glob
 
 import udiskie
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('DBus', '1.0')
+gi.require_version('Notify', '0.7')
 
 # check availability of runtime dependencies
 def check_dependency(package):


### PR DESCRIPTION
Installing updates to python and gi library on my system broke udiskie; this patch fixes the problem.