### PR TITLE
Fix build when the default encoding is not utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import sys
 import logging
 from os import path, listdir
 from glob import glob
+import io
 
 import udiskie
 
@@ -41,8 +42,8 @@ check_dependency('gi.repository.Notify', '0.7')
 # read long_description from README.rst
 long_description = None
 try:
-    long_description = open('README.rst').read()
-    long_description += '\n' + open('CHANGES.rst').read()
+    long_description = open('README.rst', encoding='utf-8').read()
+    long_description += '\n' + open('CHANGES.rst', encoding='utf-8').read()
 except IOError:
     pass
 


### PR DESCRIPTION
```
dh_auto_clean
I: pybuild base:184: python3.4 setup.py clean 
WARNING:root:Missing runtime dependencies:
	Namespace Gtk not available
WARNING:root:Missing runtime dependencies:
	Namespace Notify not available
Traceback (most recent call last):
  File "setup.py", line 44, in <module>
    long_description = open('README.rst').read()
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 286: ordinal not in range(128)
E: pybuild pybuild:274: clean: plugin distutils failed with: exit code=1: python3.4 setup.py clean 
dh_auto_clean: pybuild --clean -i python{version} -p 3.4 3.5 --dir . returned exit code 13
debian/rules:9: recipe for target 'override_dh_auto_clean' failed
```