### PR TITLE
Command line option --notify-command COMMAND

### DIFF
--- a/udiskie/cli.py
+++ b/udiskie/cli.py
@@ -340,6 +340,9 @@ class Daemon(_EntryPoint):
         -p COMMAND, --password-prompt COMMAND   Command for password retrieval
         -P, --no-password-prompt                Disable unlocking
 
+        --notify-command COMMAND                Command to execute on events
+        --no-notify-command                     Disable command notifications
+
     Deprecated options:
         -f PROGRAM, --file-manager PROGRAM      Set program for browsing
         -F, --no-file-manager                   Disable browsing
@@ -356,6 +359,7 @@ class Daemon(_EntryPoint):
         'file_manager': 'xdg-open',
         'password_prompt': 'builtin:gui',
         'password_cache': False,
+        'notify-command': None,
     })
 
     option_rules = extend(_EntryPoint.option_rules, {
@@ -370,6 +374,7 @@ class Daemon(_EntryPoint):
         'file_manager': OptionalValue('--file-manager'),
         'password_prompt': OptionalValue('--password-prompt'),
         'password_cache': OptionalValue('--password-cache'),
+        'notify-command': OptionalValue('--notify-command')
     })
 
     def _init(self):
@@ -441,6 +446,11 @@ class Daemon(_EntryPoint):
                                   mounter=mounter,
                                   timeout=config.notifications,
                                   aconfig=aconfig)
+
+        # command notifincations (optional):
+        if options["notify-command"]:
+            import udiskie.cmdnotify
+            udiskie.cmdnotify.CommandNotify(options['notify-command'], mounter)
 
         # tray icon (optional):
         if options['tray']:

--- a/udiskie/cmdnotify.py
+++ b/udiskie/cmdnotify.py
@@ -1,0 +1,77 @@
+import subprocess
+import logging
+
+
+class CommandHandler:
+    """
+    An event handler that issues a command.
+    """
+
+    _properties = [
+        "device_file",
+        "device_id",
+        "device_size",
+        "drive",
+        "drive_label",
+        "id_label",
+        "id_type",
+        "id_usage",
+        "id_uuid",
+        "mount_path",
+        "root",
+    ]
+    
+    def __init__(self, command_format, event):
+        """
+        Initialize command handler.
+
+        :param command_format: The command format string to run when the
+                               particular event occurs.
+        :param event: The event type
+        """
+        self._log = logging.getLogger(__name__)
+        self._command_format = command_format
+        self._event = event
+
+    def __call__(self, device):
+        event_info = dict([(prop_name, getattr(device, prop_name)) for prop_name in self._properties])
+        event_info["event"] = self._event
+        command = self._command_format.format(**event_info)
+        return_code = subprocess.call(command, shell = True)
+        if (return_code != 0):
+            self._log.warn("Notification command {} with event {} returned {:d}".format(command, self._event, return_code))
+
+
+class CommandNotify:
+
+    """
+    Command notification tool.
+
+    This works similar to Notify, but will issue command instead of showing
+    the notifications on the desktop. This can then be used to react to events
+    from shell scripts.
+
+    The command can contain modern pythonic format placeholders like:
+    {device_file}. The following placeholders are supported:
+    event, device_file, device_id, device_size, drive, drive_label, id_label,
+    id_type, id_usage, id_uuid, mount_path, root
+    """
+
+    def __init__(self, command_format, mounter):
+        """
+        Initialize notifier and connect to service.
+
+        :param command_format: The command format string to run when an event
+                               occurs.
+        :param mounter: Mounter object
+        """
+        udisks = mounter.udisks
+        # Subscribe all enabled events to the daemon:
+        udisks = mounter.udisks
+        for event in ['device_mounted', 'device_unmounted',
+                      'device_locked', 'device_unlocked',
+                      'device_added', 'device_removed',
+                      'job_failed']:
+            udisks.connect(event, CommandHandler(command_format, event))
+
+    


### PR DESCRIPTION
I added a command line option `--notify-command COMMAND` which allows the user to specify an arbitrary command to be executed when an event occurs.

The command can be parameterized using `{name}` placeholders (python format strings) where name can be a subset of properties of a Device.

@coldfix I know you want tests for pull requests, but unfortunately I can't allocate time for that right now. Nevertheless I'm interested about your opinion about such a feature.