### PR TITLE
Unmount cleartext device before locking

### DIFF
--- a/udiskie/mount.py
+++ b/udiskie/mount.py
@@ -289,6 +289,7 @@ class Mounter:
         if not device.is_unlocked:
             self._log.info(_('not locking {0}: not unlocked', device))
             return True
+        await self.unmount(device.luks_cleartext_holder)
         self._log.debug(_('locking {0}', device))
         await device.lock()
         self._log.info(_('locked {0}', device))

--- a/udiskie/udisks2.py
+++ b/udiskie/udisks2.py
@@ -463,10 +463,7 @@ class Device:
         """Get wrapper to the unlocked luks cleartext device."""
         if not self.is_luks:
             return None
-        for device in self._daemon:
-            if device.luks_cleartext_slave == self:
-                return device
-        return None
+        return self._daemon[self._P.Encrypted.CleartextDevice]
 
     @property
     def is_unlocked(self):


### PR DESCRIPTION
It's possible to unlock and mount encrypted partition in one go:

	% udiskie-mount /dev/disk/by-label/cryptdisk -p 'pass cryptdisk' -r
	unlocked /org/freedesktop/UDisks2/block_devices/sdb2
	mounted /org/freedesktop/UDisks2/block_devices/dm_2d1 on /run/media/woky/cleardisk

But without this patch it's impossible to unmount and lock it via
corresponding command:

	% udiskie-umount /dev/disk/by-label/cryptdisk
	failed to lock /org/freedesktop/UDisks2/block_devices/sdb2: GDBus.Error:org.freedesktop.UDisks2.Error.Failed: Error locking /dev/dm-1 (/dev/sdb2): Failed to deactivate device: Device or resource busy

With this patch it is possible:

	% udiskie-umount /dev/disk/by-label/cryptdisk
	unmounted /org/freedesktop/UDisks2/block_devices/dm_2d1
	locked /org/freedesktop/UDisks2/block_devices/sdb2