### PR TITLE
Rather than forcing installation of importlib_resources,

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >=3.5
 install_requires =
     PyYAML
     docopt
-    importlib_resources
+    importlib_resources;python_version<'3.7'
     PyGObject
 
 [options.extras_require]

--- a/udiskie/prompt.py
+++ b/udiskie/prompt.py
@@ -12,7 +12,10 @@ import string
 import subprocess
 import sys
 
-from importlib_resources import read_text
+try:
+    from importlib.resources import read_text
+except ImportError:  # for Python<3.7
+    from importlib_resources import read_text
 
 from .async_ import exec_subprocess, run_bg, Future
 from .locale import _


### PR DESCRIPTION
Try to import importlib.resources from python3.7 and onwards