### PR TITLE
Update setup.py to install zsh bash completions into the correct dire…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         'build_mo': build_mo,
     },
     data_files=[
-        ('share/zsh/site-functions', comp_files),
+        ('share/zsh/vendor-completions', comp_files),
         *[('share/locale/{}/LC_MESSAGES'.format(lang),
            ['build/locale/{}/LC_MESSAGES/udiskie.mo'.format(lang)])
           for lang in languages],


### PR DESCRIPTION
…ctory

According to [1] a path like /usr/share/zsh/vendor-completions
Is probably a better place to put such files, because site-functions directory might
not work everywhere (e.g. in Debian based systems)

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=982442