### PR TITLE
In the config file, accept lists of possible values, and the rule matches if the attribute is any of the specified values.

### DIFF
--- a/doc/udiskie.8.txt
+++ b/doc/udiskie.8.txt
@@ -232,10 +232,14 @@ device_config:
   # The rules defined here are simply prepended to the builtin device rules,
   # so that it is possible to completely overwrite the defaults by specifying
   # a catch-all rule (i.e. a rule without device attributes).
+  # Filter rules can be passed a list of values, in which case the rule is matched
+  # if the attribute matches any of the values in the list.
 
 - device_file: /dev/dm-5    # [filter]
   ignore:      false        # [action] never ignore this device
-- id_uuid: 9d53-13ba        # [filter] match by device UUID
+- id_uuid:                  # [filter] match by device UUID
+  - 9d53-13ba               # This rule matches on either of these uids
+  - 8675-309a
   options: [noexec, nodev]  # [action] mount options can be given as list
   ignore:  false            # [action] never ignore this device (even if fs=FAT)
   automount: false          # [action] do not automount this device

--- a/udiskie/config.py
+++ b/udiskie/config.py
@@ -42,6 +42,8 @@ def _format_item(k, v):
 def match_value(value, pattern):
     if isinstance(value, (list, tuple)):
         return any(match_value(v, pattern) for v in value)
+    if isinstance(pattern, (list, tuple)):
+        return any(match_value(value, p) for p in pattern)
     if isinstance(value, str) and isinstance(pattern, str):
         return fnmatch.fnmatch(value.lower(), pattern.lower())
     return lower(value) == lower(pattern)


### PR DESCRIPTION
This makes it easier to write a config file that specifies ten uuids that should be handled specially, rather than requiring ten rules, any one of which might accidentally get out of sync or contain a typo.