### PR TITLE
Fix size of password dialog

### DIFF
--- a/udiskie/password_dialog.ui
+++ b/udiskie/password_dialog.ui
@@ -3,6 +3,7 @@
     <property name="border_width">5</property>
     <property name="window_position">center</property>
     <property name="type_hint">dialog</property>
+    <property name="resizable">False</property>
     <property name="role">password-dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="entry_box">


### PR DESCRIPTION
Users of a tiling window manager will mostly enjoy this feature, as the password prompt will float over all other windows by default.
Tested with Sway 1.10.1.
