### PR TITLE
Fix typo in function name

### DIFF
--- a/udiskie/appindicator.py
+++ b/udiskie/appindicator.py
@@ -57,7 +57,7 @@ class AppIndicatorIcon:
         self._indicator.set_status(status)
 
     def _on_show(self, menu):
-        self._update_menu()
+        self.update_menu()
 
     def update_menu(self, *args):
         # TODO: Remove/add/modify only those entries menuitems that actually


### PR DESCRIPTION
Pretty sure `_update_menu` was a typo, there's no function with that name. And running udiskie in the terminal and clicking the tray icon showed the error:

```console
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/udiskie/appindicator.py", line 60, in _on_show
    self._update_menu()
    ^^^^^^^^^^^^^^^^^
AttributeError: 'AppIndicatorIcon' object has no attribute '_update_menu'. Did you mean: 'update_menu'?
```